### PR TITLE
Add structural tag output parser and tests

### DIFF
--- a/cpp/structural_tag.h
+++ b/cpp/structural_tag.h
@@ -24,6 +24,7 @@ namespace xgrammar {
 
 // TODO(yixin): Consider moving the definition to Public API.
 
+struct ParserTag;
 struct ConstStringFormat;
 struct JSONSchemaFormat;
 struct QwenXmlParameterFormat;
@@ -51,6 +52,12 @@ using Format = std::variant<
 
 /******************** Basic Formats ********************/
 
+struct ParserTag {
+  std::optional<std::string> capture_id;
+  std::optional<std::string> combine;
+  std::optional<std::string> metadata_json;
+};
+
 struct ConstStringFormat {
   static constexpr const char* type = "const_string";
   std::string value;
@@ -60,13 +67,19 @@ struct ConstStringFormat {
 struct JSONSchemaFormat {
   static constexpr const char* type = "json_schema";
   std::string json_schema;
-  JSONSchemaFormat(std::string json_schema) : json_schema(std::move(json_schema)) {}
+  std::optional<ParserTag> parser_tag;
+  JSONSchemaFormat(std::string json_schema, std::optional<ParserTag> parser_tag = std::nullopt)
+      : json_schema(std::move(json_schema)), parser_tag(std::move(parser_tag)) {}
 };
 
 struct QwenXmlParameterFormat {
   static constexpr const char* type = "qwen_xml";
   std::string xml_schema;
-  QwenXmlParameterFormat(std::string xml_schema) : xml_schema(std::move(xml_schema)) {}
+  std::optional<ParserTag> parser_tag;
+  QwenXmlParameterFormat(
+      std::string xml_schema, std::optional<ParserTag> parser_tag = std::nullopt
+  )
+      : xml_schema(std::move(xml_schema)), parser_tag(std::move(parser_tag)) {}
 };
 
 struct GrammarFormat {
@@ -78,12 +91,17 @@ struct GrammarFormat {
 struct RegexFormat {
   static constexpr const char* type = "regex";
   std::string pattern;
-  RegexFormat(std::string pattern) : pattern(std::move(pattern)) {}
+  std::optional<ParserTag> parser_tag;
+  RegexFormat(std::string pattern, std::optional<ParserTag> parser_tag = std::nullopt)
+      : pattern(std::move(pattern)), parser_tag(std::move(parser_tag)) {}
 };
 
 struct AnyTextFormat {
   static constexpr const char* type = "any_text";
-  AnyTextFormat() {}
+  std::optional<ParserTag> parser_tag;
+
+  AnyTextFormat(std::optional<ParserTag> parser_tag = std::nullopt)
+      : parser_tag(std::move(parser_tag)) {}
 
  private:
   // Detected in StructuralTagAnalyzer
@@ -123,9 +141,18 @@ struct TagFormat {
   std::string begin;
   std::shared_ptr<Format> content;
   std::string end;
+  std::optional<ParserTag> parser_tag;
 
-  TagFormat(std::string begin, std::shared_ptr<Format> content, std::string end)
-      : begin(std::move(begin)), content(std::move(content)), end(std::move(end)) {}
+  TagFormat(
+      std::string begin,
+      std::shared_ptr<Format> content,
+      std::string end,
+      std::optional<ParserTag> parser_tag = std::nullopt
+  )
+      : begin(std::move(begin)),
+        content(std::move(content)),
+        end(std::move(end)),
+        parser_tag(std::move(parser_tag)) {}
 };
 
 struct TriggeredTagsFormat {
@@ -134,17 +161,20 @@ struct TriggeredTagsFormat {
   std::vector<TagFormat> tags;
   bool at_least_one = false;
   bool stop_after_first = false;
+  std::optional<ParserTag> parser_tag;
 
   TriggeredTagsFormat(
       std::vector<std::string> triggers,
       std::vector<TagFormat> tags,
       bool at_least_one,
-      bool stop_after_first
+      bool stop_after_first,
+      std::optional<ParserTag> parser_tag = std::nullopt
   )
       : triggers(std::move(triggers)),
         tags(std::move(tags)),
         at_least_one(at_least_one),
-        stop_after_first(stop_after_first) {}
+        stop_after_first(stop_after_first),
+        parser_tag(std::move(parser_tag)) {}
 
  private:
   // Detected in StructuralTagAnalyzer
@@ -159,14 +189,20 @@ struct TagsWithSeparatorFormat {
   std::string separator;
   bool at_least_one = false;
   bool stop_after_first = false;
+  std::optional<ParserTag> parser_tag;
 
   TagsWithSeparatorFormat(
-      std::vector<TagFormat> tags, std::string separator, bool at_least_one, bool stop_after_first
+      std::vector<TagFormat> tags,
+      std::string separator,
+      bool at_least_one,
+      bool stop_after_first,
+      std::optional<ParserTag> parser_tag = std::nullopt
   )
       : tags(std::move(tags)),
         separator(std::move(separator)),
         at_least_one(at_least_one),
-        stop_after_first(stop_after_first) {}
+        stop_after_first(stop_after_first),
+        parser_tag(std::move(parser_tag)) {}
 
  private:
   // Detected in StructuralTagAnalyzer

--- a/tests/python/test_structural_tag_parser.py
+++ b/tests/python/test_structural_tag_parser.py
@@ -1,0 +1,127 @@
+"""Tests for parsing structural tag outputs with parser tags."""
+
+import importlib.util
+from pathlib import Path
+
+STRUCTURAL_TAG_PATH = Path(__file__).resolve().parents[2] / "python" / "xgrammar" / "structural_tag.py"
+spec = importlib.util.spec_from_file_location("xgrammar.structural_tag", STRUCTURAL_TAG_PATH)
+structural_tag = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(structural_tag)
+
+
+def test_parse_triggered_tags_tool_calls():
+    tool_call_schema = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"},
+            "arguments": {"type": "object"},
+        },
+        "required": ["name", "arguments"],
+    }
+
+    tool_calls_format = structural_tag.TriggeredTagsFormat(
+        triggers=["<tool_call>"],
+        tags=[
+            structural_tag.TagFormat(
+                begin="<tool_call>",
+                content=structural_tag.JSONSchemaFormat(
+                    json_schema=tool_call_schema,
+                    parser_tag={"capture_id": "item"},
+                ),
+                end="</tool_call>",
+            )
+        ],
+        parser_tag={"capture_id": "tool_calls", "combine": "append"},
+    )
+
+    output = (
+        "<tool_call>{\"name\": \"weather\", \"arguments\": {\"location\": \"sf\"}}</tool_call>"
+        "<tool_call>{\"name\": \"time\", \"arguments\": {}}</tool_call>"
+    )
+
+    parsed = structural_tag.parse_structural_tag_output(tool_calls_format, output)
+
+    assert parsed == {
+        "tool_calls": [
+            {"name": "weather", "arguments": {"location": "sf"}},
+            {"name": "time", "arguments": {}},
+        ]
+    }
+
+
+def test_parse_tags_with_separator_messages():
+    message_schema = {
+        "type": "object",
+        "properties": {
+            "role": {"type": "string"},
+            "content": {"type": "string"},
+        },
+        "required": ["role", "content"],
+    }
+
+    messages_format = structural_tag.TagsWithSeparatorFormat(
+        tags=[
+            structural_tag.TagFormat(
+                begin="<message>",
+                content=structural_tag.JSONSchemaFormat(
+                    json_schema=message_schema,
+                    parser_tag={"capture_id": "item"},
+                ),
+                end="</message>",
+            )
+        ],
+        separator="\n",
+        parser_tag={"capture_id": "messages", "combine": "append"},
+    )
+
+    output = (
+        "<message>{\"role\": \"assistant\", \"content\": \"Hi there\"}</message>\n"
+        "<message>{\"role\": \"tool\", \"content\": \"Done\"}</message>"
+    )
+
+    parsed = structural_tag.parse_structural_tag_output(messages_format, output)
+
+    assert parsed == {
+        "messages": [
+            {"role": "assistant", "content": "Hi there"},
+            {"role": "tool", "content": "Done"},
+        ]
+    }
+
+
+def test_parse_concat_from_triggered_segments():
+    concat_format = structural_tag.TriggeredTagsFormat(
+        triggers=["<part>"],
+        tags=[
+            structural_tag.TagFormat(
+                begin="<part>",
+                content=structural_tag.AnyTextFormat(
+                    parser_tag={"capture_id": "item"}
+                ),
+                end="</part>",
+            )
+        ],
+        parser_tag={"capture_id": "content", "combine": "concat"},
+    )
+
+    output = "<part>Hello</part>\n<part>World</part>"
+
+    parsed = structural_tag.parse_structural_tag_output(concat_format, output)
+
+    assert parsed == {"content": "HelloWorld"}
+
+
+def test_parse_nested_paths_from_tag():
+    message_format = structural_tag.TagFormat(
+        begin="<message>",
+        content=structural_tag.AnyTextFormat(
+            parser_tag={"capture_id": "content"}
+        ),
+        end="</message>",
+        parser_tag={"capture_id": "message"},
+    )
+
+    parsed = structural_tag.parse_structural_tag_output(message_format, "<message>Hi</message>")
+
+    assert parsed == {"message": {"content": "Hi"}}


### PR DESCRIPTION
## Summary
- implement a structural tag output parser that interprets parser_tag capture metadata and assembles structured results
- expose helpers for parsing triggered tags, separator-based tags, and leaves while supporting append/concat combines
- add regression tests that exercise tool-call parsing, message lists, concat combines, and nested path captures

## Testing
- pytest tests/python/test_structural_tag_parser.py

------
https://chatgpt.com/codex/tasks/task_b_68e537a5074483259da05fe5a921eec1